### PR TITLE
Hotfix: Fix issue with queues being paused

### DIFF
--- a/Taskmaster/build.gradle
+++ b/Taskmaster/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java-library'
 
 group 'com.livio.taskmaster'
-version '0.3'
+version '0.4'
 
 sourceCompatibility = 1.7
 

--- a/Taskmaster/src/main/java/com/livio/taskmaster/Taskmaster.java
+++ b/Taskmaster/src/main/java/com/livio/taskmaster/Taskmaster.java
@@ -156,6 +156,10 @@ public class Taskmaster {
 
             Task peekTask;
             for (Queue queue : queues) {
+                if (queue.isPaused()) {
+                    //Paused queues should be skipped.
+                    continue;
+                }
                 peekTask = queue.peekNextTask();
                 if (peekTask != null && peekTask.getState() == Task.READY) {
                     peekWeight = peekTask.getWeight(currentTime);

--- a/Taskmaster/src/test/java/com/livio/taskmaster/smoketests/PauseTest.java
+++ b/Taskmaster/src/test/java/com/livio/taskmaster/smoketests/PauseTest.java
@@ -1,0 +1,70 @@
+package com.livio.taskmaster.smoketests;
+
+import com.livio.taskmaster.Queue;
+import com.livio.taskmaster.Task;
+
+public class PauseTest extends BaseTest {
+    Queue queue1, queue2;
+
+    public PauseTest(ITest callback) {
+        super(2, callback);
+    }
+
+    public void setUp() {
+
+        queue1 = taskmaster.createQueue("Queue 1", 1, false);
+        queue1.add(generateTask("1"), false);
+        queue1.add(generateTask("2"), false);
+        queue1.add(generateTask("3"), false);
+        queue1.add(generateTask("4"), false);
+        numberOfGeneratedTasks++;
+        queue1.add(taskA, false);
+        numberOfGeneratedTasks++;
+        queue1.add(new Task("Final task") {
+            @Override
+            public void onExecute() {
+                System.out.println("-------- Final Task is executing, test should end after this");
+                PauseTest.this.endTest(true);
+                this.onFinished();
+            }
+        }, false);
+
+
+        queue2 = taskmaster.createQueue("Queue 2", 2, false);
+        queue2.pause();
+        queue2.add(generateTask("21"), false);
+        queue2.add(generateTask("22"), false);
+        queue2.add(generateTask("23"), false);
+        queue2.add(generateTask("24"), false);
+        numberOfGeneratedTasks++;
+        queue2.add(taskB, false);
+    }
+
+    Task taskA = new Task("-- Task A --") {
+
+        @Override
+        public void onExecute() {
+            System.out.println("-------- Running task A, should pause queue1, resume queue2");
+            if (taskmaster != null && queue1 != null) {
+                queue1.pause();
+                queue2.resume();
+            }
+            this.onFinished();
+        }
+    };
+
+    Task taskB = new Task("-- Task B --") {
+
+        @Override
+        public void onExecute() {
+            System.out.println("-------- Running task B, should resume queue1");
+
+            if (taskmaster != null && queue1 != null) {
+                queue1.resume();
+            }
+            this.onFinished();
+        }
+    };
+
+
+}

--- a/Taskmaster/src/test/java/com/livio/taskmaster/smoketests/Tests.java
+++ b/Taskmaster/src/test/java/com/livio/taskmaster/smoketests/Tests.java
@@ -46,7 +46,7 @@ public class Tests {
             @Override
             public void onTestCompleted(boolean success) {
                 System.out.println("Finished simple test");
-                QueueModTest queueModTest = new QueueModTest(new BaseTest.ITest(){
+                QueueModTest queueModTest = new QueueModTest(new BaseTest.ITest() {
                     @Override
                     public void onTestCompleted(boolean success) {
                         System.out.println("Finished queue mod test");
@@ -56,10 +56,16 @@ public class Tests {
                             public void onTestCompleted(boolean success) {
                                 System.out.println("Finished big test");
 
+                                PauseTest pauseTest = new PauseTest(new BaseTest.ITest() {
+                                    @Override
+                                    public void onTestCompleted(boolean success) {
+                                        System.out.println("Finished pause test");
+                                    }
+                                });
+                                pauseTest.start();
                             }
                         });
                         bigTest.start();
-
                     }
                 });
                 queueModTest.start();
@@ -89,6 +95,7 @@ public class Tests {
 
         }).start();
         */
+
     }
 
 


### PR DESCRIPTION
The Taskmaster will now check if a queue is paused while attempting to determine the priority queue. If it is paused, it will skip over that queue and continue to check the remaining queues.

Previously, if the queue was paused it could be selected as the priority queue which meant that it wouldn't have a task to give the Taskmaster. This caused the system to sleep as it assumed no tasks were available once the queue was polled. (Peek returns the next task, but poll checks if it is paused and would return null if it was.)