### PR TITLE
Fixe Issue #12: Handle quickly canceled tasks before operations

### DIFF
--- a/Taskmaster/src/test/java/com/livio/taskmaster/smoketests/CancelTasksTest.java
+++ b/Taskmaster/src/test/java/com/livio/taskmaster/smoketests/CancelTasksTest.java
@@ -1,0 +1,50 @@
+package com.livio.taskmaster.smoketests;
+
+import com.livio.taskmaster.Queue;
+import com.livio.taskmaster.Task;
+
+public class CancelTasksTest extends BaseTest {
+    Queue queue;
+
+    public CancelTasksTest(ITest callback) {
+        super(1, callback);
+    }
+
+    @Override
+    public void setUp() {
+        queue = taskmaster.createQueue("Queue", 1, false);
+        queue.add(taskA, false);
+        taskA.cancelTask();
+        queue.add(taskB, false);
+        queue.add(taskC, false);
+    }
+
+
+    Task taskA = new Task("-- Task A --") {
+
+        @Override
+        public void onExecute() {
+            System.out.println("-------- Running task A, this should not happen");
+            this.onFinished();
+        }
+    };
+
+    Task taskB = new Task("-- Task B --") {
+
+        @Override
+        public void onExecute() {
+            System.out.println("-------- Running task B");
+            this.onFinished();
+        }
+    };
+    Task taskC = new Task("-- Task C --") {
+
+        @Override
+        public void onExecute() {
+            System.out.println("-------- Running task C");
+            this.onFinished();
+            taskmaster.shutdown();
+            onTestCompleted(true);
+        }
+    };
+}


### PR DESCRIPTION
### Fixing stuck queue with canceled head

Fixes #12 

- The queue would get stuck if the task at the head of the queue was canceled before any operation was started on that queue. The updates will ensure that if there is no current task that all stale tasks are removed.
- Refactored to remove all types of stale task in the queue instead of just canceled.
- Refactored the test class to avoid the callback hell that was happening. 