### PR TITLE
Fix Thread lock logic

### DIFF
--- a/Taskmaster/src/main/java/com/livio/taskmaster/Taskmaster.java
+++ b/Taskmaster/src/main/java/com/livio/taskmaster/Taskmaster.java
@@ -224,9 +224,8 @@ public class Taskmaster {
         }
 
         private void alert() {
-
-            if (isWaiting) {
-                synchronized (TASK_THREAD_LOCK) {
+            synchronized (TASK_THREAD_LOCK) {
+                if (isWaiting) {
                     TASK_THREAD_LOCK.notify();
                 }
             }


### PR DESCRIPTION
Fixes #16 

- This Pr fixes a case where a Thread would not get notified that it needs to start executing as logic to check that it was waiting was outside of its Lock in rare cases. 

